### PR TITLE
Adding defaultMode for replication in orm config

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -569,7 +569,23 @@ export class Connection {
                 return DriverUtils.buildMongoDBDriverOptions(options).database;
             default:
                 return DriverUtils.buildDriverOptions(options).database;
+        }
     }
-}
 
+    /**
+     * Get the replication mode SELECT queries should use for this datasource by default
+     */
+    defaultReplicationModeForReads(): ReplicationMode {
+        if ("replication" in this.driver.options) {
+            const value = (
+                this.driver.options.replication as {
+                    defaultMode?: ReplicationMode
+                }
+            ).defaultMode
+            if (value) {
+                return value
+            }
+        }
+        return "slave"
+    }
 }

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -1,4 +1,5 @@
 import {BaseConnectionOptions} from "../../connection/BaseConnectionOptions";
+import { ReplicationMode } from "../types/ReplicationMode";
 import {PostgresConnectionCredentialsOptions} from "./PostgresConnectionCredentialsOptions";
 
 /**
@@ -36,6 +37,11 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
          */
         readonly slaves: PostgresConnectionCredentialsOptions[];
 
+        /**
+         * Default connection pool to use for SELECT queries
+         * @default "slave"
+         */
+        readonly defaultMode?: ReplicationMode;
     };
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2123,7 +2123,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral> extends QueryBuild
      * Creates a query builder used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner("slave");
+        return this.queryRunner || this.connection.createQueryRunner(
+            this.connection.defaultReplicationModeForReads(),
+        );
     }
 
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

When we add `replication` to orm config, all read queries are directed to slaves by default. Using `defaultMode` we can set master as default for all read queries and then explicitly specify slaves for any connections we want to use replicas.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
